### PR TITLE
Adds a new standard application error code CodeTimeout to the apperror package

### DIFF
--- a/apperror/README.md
+++ b/apperror/README.md
@@ -28,6 +28,7 @@ Available code constants:
 - `CodeForbidden`
 - `CodeConflict`
 - `CodeInternal`
+- `CodeTimeout`
 - `CodeNotImplemented`
 - `CodeUnknown`
 

--- a/apperror/errors.go
+++ b/apperror/errors.go
@@ -18,6 +18,7 @@ const (
 	CodeForbidden      Code = "FORBIDDEN"
 	CodeConflict       Code = "CONFLICT"
 	CodeInternal       Code = "INTERNAL"
+	CodeTimeout        Code = "TIMEOUT"
 	CodeNotImplemented Code = "NOT_IMPLEMENTED"
 	CodeUnknown        Code = "UNKNOWN"
 )

--- a/apperror/errors_test.go
+++ b/apperror/errors_test.go
@@ -84,6 +84,17 @@ func TestMetaGetterReturnsCopy(t *testing.T) {
 }
 
 func TestCodeOfAndMessageOf(t *testing.T) {
+	timeoutErr := New(CodeTimeout, "request timed out")
+	if got := timeoutErr.Code(); got != CodeTimeout {
+		t.Fatalf("expected timeout code %s, got %s", CodeTimeout, got)
+	}
+	if got := CodeOf(timeoutErr); got != CodeTimeout {
+		t.Fatalf("expected CodeOf(timeoutErr) to be %s, got %s", CodeTimeout, got)
+	}
+	if got := timeoutErr.Error(); got != "[TIMEOUT] request timed out" {
+		t.Fatalf("unexpected timeout error string: %q", got)
+	}
+
 	root := errors.New("transport closed")
 	wrapped := Wrap(CodeInternal, "rpc failed", root)
 


### PR DESCRIPTION
## Pull Request Content

## Summary

Adds a new standard application error code `CodeTimeout` (`"TIMEOUT"`) to the `apperror` package and updates package documentation accordingly.

## Related Issues

### ✅ Issues closed by this PR

* Closes #16 

### 🔗 Issues referenced (not closed)

N/A

## What Changed

* Added `CodeTimeout Code = "TIMEOUT"` in `apperror/errors.go`.
* Updated `apperror/README.md` to include `CodeTimeout` in the documented list of available error codes.
* Verified package behavior via tests: `go test ./...` in `apperror` module.

## Why

* Timeout errors are currently represented using broader/generic codes.
* A dedicated timeout code improves error semantics, observability, and downstream handling (for example, retry decisions and alerting classification).

## How to Test

1. From repo root, run:
   `cd apperror && go test ./...`
2. Confirm tests pass and review:
   - `apperror/errors.go` contains `CodeTimeout`.
   - `apperror/README.md` lists `CodeTimeout` among supported codes.

## Screenshots / Logs (if applicable)
Test output:
```
$ go test 
PASS
ok      github.com/routerarchitects/ra-common-mods/apperror     0.002s
```
## Impact

* Backward-compatible change.
* No breaking API changes.
* Enables more precise classification of timeout failures across services/modules using `apperror`.

## Dependencies

* None.

## Checklist

* [x] Documentation updated (if applicable)
* [x] Backward compatibility considered

## Notes for Reviewers

* Please verify naming/value consistency with existing error code conventions in `apperror`.
* Please confirm downstream services can start adopting `CodeTimeout` for timeout-specific failures.