### PR TITLE
Cache implementation

### DIFF
--- a/cache/CACHE_MODULE_SPEC.md
+++ b/cache/CACHE_MODULE_SPEC.md
@@ -81,6 +81,9 @@ Normalization rules:
 - remove surrounding `:`
 - lowercase
 - replace spaces with `-`
+- reject empty required fields after normalization
+- reject values containing internal `:` for required fields and qualifiers
+- allowed characters per segment: `a-z`, `0-9`, `.`, `_`, `-`
 
 ### 2.3 Data Flow Design
 #### Get Flow
@@ -108,6 +111,11 @@ Normalization rules:
 - try lock acquire
 - if lock acquired: double-check cache, then loader+set, release lock
 - if lock not acquired: retry cache read until timeout, else fallback loader
+
+Loader-to-destination rule:
+- `loader` returns `any` while `GetOrSet` returns only `error`.
+- The module serializes loader output with configured codec and deserializes into `dest`.
+- `dest` must be a non-nil writable pointer target.
 
 ### 2.4 Stampede Protection Design
 - Lock key shape:
@@ -141,6 +149,12 @@ Logging approach:
 - logger source: `logger.Subsystem("cache")`
 - structured fields include: `operation`, `domain`, `entity`, `backend`, `error`, `key_hash`
 - redis failures are logged at warn/error based on path criticality
+
+Graceful degradation contract (`GetOrSet`):
+- Redis `Get` failure: log warn and fallback to loader.
+- Lock acquire failure: log warn and fallback to loader.
+- Lock wait timeout: fallback to loader (current default behavior).
+- Cache `Set` failure after successful loader: log warn and still return loaded value (DB/source remains truth).
 
 ---
 
@@ -227,7 +241,7 @@ type Codec interface {
 
 ```go
 // redis/redis.go
-func New(cfg cache.Config) (*Cache, error)
+func New(cfg cache.Config) (cache.Cache, error)
 ```
 
 ```go
@@ -257,7 +271,8 @@ func ValidateKey(key Key) error
 
 #### `Delete(ctx, keys...) error`
 - No-op if no keys provided.
-- Returns validation error for invalid key.
+- Validates and builds all keys before executing delete.
+- If any key is invalid, returns validation error and performs no delete.
 
 #### `Exists(ctx, key) (bool, error)`
 - Returns `true` if key exists, else `false`.
@@ -275,6 +290,10 @@ func ValidateKey(key Key) error
 - Returns `nil` if backend reachable.
 - Returns `CodeInternal` wrapped Redis error on failure.
 
+Health-check interface note:
+- `Ping` is intentionally not part of the minimal `Cache` interface.
+- Redis implementation satisfies both `cache.Cache` and `cache.HealthChecker`.
+
 ---
 
 ## 4. Integration Spec
@@ -284,6 +303,32 @@ func ValidateKey(key Key) error
 2. Create cache instance once at startup via `redis.New(cfg)`.
 3. Pass around as `cache.Cache` interface.
 4. Close at shutdown.
+
+### 4.1.1 Config Validation and Defaults Contract
+- Mode default:
+1. Empty `Mode` is treated as `standalone`.
+- Address requirements:
+1. `standalone`: at least one address; first address is used.
+2. `sentinel`: one or more sentinel addresses and `MasterName` required.
+3. `cluster`: one or more node addresses required.
+- Prefix precedence:
+1. If `KeyPrefix` is set, it is used.
+2. Else normalized `ServiceName` is used.
+3. At least one of `KeyPrefix` or `ServiceName` must be non-empty after normalization.
+- TTL behavior:
+1. `Set` uses method TTL when `ttl > 0`.
+2. Otherwise uses `DefaultTTL`.
+3. If effective TTL is not positive, return `CodeInvalidInput`.
+- Timeout defaults (when unset):
+1. `DialTimeout = 2s`
+2. `ReadTimeout = 500ms`
+3. `WriteTimeout = 500ms`
+- Lock defaults (when stampede protection settings are unset):
+1. `LockTTL = 3s`
+2. `LockWaitTimeout = 2s`
+3. `LockRetryInterval = 100ms`
+- Cluster DB rule:
+1. In `cluster` mode, `DB` must be `0`.
 
 ### 4.2 Example Initialization
 
@@ -306,6 +351,12 @@ if err != nil {
     return err
 }
 defer c.Close()
+
+if hc, ok := c.(cache.HealthChecker); ok {
+    if err := hc.Ping(ctx); err != nil {
+        // mark service as degraded or fail readiness based on policy
+    }
+}
 ```
 
 ### 4.3 Example Read Path (`GetOrSet`)
@@ -361,3 +412,56 @@ if err := c.Delete(ctx, key); err != nil {
 - Enable stampede protection for hot keys/high concurrency reads.
 - Avoid using cache as source of truth.
 - Treat Redis outages as degraded performance where business permits.
+
+---
+
+## 5. Future Scope
+
+### 5.1 Observability Enhancements
+- Define a standard cache metrics contract:
+1. `cache_get_total`
+2. `cache_hit_total`
+3. `cache_miss_total`
+4. `cache_set_total`
+5. `cache_delete_total`
+6. `cache_error_total`
+7. latency histograms for `get`, `set`, and `loader`
+- Add tracing hooks for cache spans and loader spans.
+
+### 5.2 Resilience and Fallback Controls
+- Add configurable behavior for lock wait timeout:
+1. strict timeout error
+2. loader fallback (current behavior)
+- Add optional circuit-breaker style protection for repeated Redis failures.
+
+### 5.3 Serialization and Data Handling
+- Support pluggable codecs beyond JSON (for example MsgPack/Protobuf).
+- Add optional payload compression for large cache values.
+- Add optional encryption for sensitive cache payloads.
+
+### 5.4 TTL Strategy Improvements
+- Add TTL jitter to avoid synchronized expiration bursts.
+- Add policy-driven TTL profiles by data category (profile/config/search/aggregate).
+
+### 5.5 Invalidation and Key Management
+- Add first-class support for batch/group invalidation patterns.
+- Define event-driven invalidation integration patterns for write-heavy domains.
+
+### 5.6 Operational and Compliance Guidance
+- Add service integration checklist for rollout readiness.
+- Add conformance test guidelines to validate service-side usage against this spec.
+
+### 5.7 Advanced Redis Operations (Optional)
+- Add bulk APIs for high-throughput paths:
+1. `MGet(ctx, keys...)`
+2. `MSet(ctx, items, ttl)` (or equivalent batch set contract)
+- Add counter APIs for quota/rate/statistics use cases:
+1. `Incr(ctx, key)`
+2. `IncrBy(ctx, key, delta)`
+3. `Decr(ctx, key)`
+4. `DecrBy(ctx, key, delta)`
+- Add hash APIs for partial object operations:
+1. `HGet(ctx, key, field)`
+2. `HSet(ctx, key, fieldValues...)`
+3. `HMGet(ctx, key, fields...)`
+- Keep these capabilities as optional sub-interfaces so core cache consumers can continue using the minimal `Cache` interface.

--- a/cache/CACHE_MODULE_SPEC.md
+++ b/cache/CACHE_MODULE_SPEC.md
@@ -1,0 +1,363 @@
+# Redis Cache Common Module Spec
+
+## 1. Requirement Spec
+
+### 1.1 Purpose
+The cache module provides a shared Redis-backed caching abstraction for all services. It centralizes key generation, TTL handling, serialization, Redis operations, and error/logging conventions.
+
+### 1.2 Business and Engineering Goals
+- Reduce duplicated cache code across services.
+- Hide Redis-specific details from business code.
+- Enforce consistent key schema and service isolation.
+- Support horizontally scaled service instances with predictable cache behavior.
+- Provide graceful degradation when Redis is unavailable.
+
+### 1.3 Functional Requirements
+- Expose a common cache interface with:
+1. `Get`
+2. `Set`
+3. `Delete`
+4. `Exists`
+5. `GetOrSet`
+6. `Close`
+- Accept only structured cache keys from services.
+- Internally generate final Redis key strings.
+- Support Redis deployment modes:
+1. `standalone`
+2. `sentinel`
+3. `cluster`
+- Support configurable default TTL and per-write TTL override.
+- Provide cache-aside read flow through `GetOrSet`.
+- Provide optional stampede protection lock for `GetOrSet` misses.
+- Provide Redis health check via `Ping`.
+
+### 1.4 Non-Functional Requirements
+- All module errors must follow `apperror` conventions.
+- All module logs must use shared `logger` module.
+- Logging should avoid full key leakage; hashed key preferred.
+- Latency-sensitive operations should avoid unnecessary lock usage (`Get/Set/Delete/Exists` remain lock-free).
+
+### 1.5 Constraints and Rules
+- Service must not pass raw Redis key strings into APIs.
+- `ServiceName` or `KeyPrefix` must be configured.
+- In cluster mode, logical DB must be `0`.
+- Effective TTL for `Set` must be positive.
+- Qualifier entries are optional and appended as normalized segments.
+
+---
+
+## 2. Design Spec
+
+### 2.1 Package Structure
+- `cache/`
+1. `cache.go`: public interfaces
+2. `config.go`: configuration model
+3. `key.go`: structured key model
+4. `key_builder.go`: key build/validation/normalization logic
+5. `codec.go`: codec interface
+6. `json_codec.go`: default JSON codec
+7. `errors.go`: cache-level error helpers
+8. `noop.go`: no-op fallback cache
+- `cache/redis/`
+1. `redis.go`: Redis cache implementation
+2. `client.go`: mode-aware Redis client creation
+3. `lock.go`: lock acquire/wait/release behavior
+4. `health.go`: ping health check
+
+### 2.2 Key Model and Generation
+Input key (service-level):
+- `Domain`, `Entity`, `ID`, `Version` are mandatory.
+- `Qualifiers` is optional.
+
+Generated key format:
+`<prefix>:<domain>:<entity>:<id>:<qualifiers...>:<version>`
+
+Example:
+- Input: `{Domain:user, Entity:profile, ID:123, Version:v1}`
+- Output: `user-service:user:profile:123:v1`
+
+Normalization rules:
+- `trimSpace`
+- remove surrounding `:`
+- lowercase
+- replace spaces with `-`
+
+### 2.3 Data Flow Design
+#### Get Flow
+1. Validate and build redis key.
+2. Execute Redis `GET`.
+3. If nil -> return cache miss (`NOT_FOUND`).
+4. Decode payload into destination object.
+
+#### Set Flow
+1. Validate and build redis key.
+2. Serialize value via codec.
+3. Resolve TTL:
+- use method TTL if `>0`
+- else use `Config.DefaultTTL`
+4. Execute Redis `SET key value ttl`.
+
+#### GetOrSet Flow
+1. Attempt cache `Get`.
+2. If hit, return.
+3. If miss and stampede protection disabled:
+- run loader
+- attempt cache `Set`
+- return loader value
+4. If miss and stampede protection enabled:
+- try lock acquire
+- if lock acquired: double-check cache, then loader+set, release lock
+- if lock not acquired: retry cache read until timeout, else fallback loader
+
+### 2.4 Stampede Protection Design
+- Lock key shape:
+`<prefix>:lock:cache:<original-key-suffix>`
+- Acquire uses `SET NX PX` semantics via `SetNX` with TTL.
+- Lock token uses unique UUID.
+- Release uses Lua compare-and-delete for ownership-safe unlock.
+
+Lua:
+```lua
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+else
+  return 0
+end
+```
+
+Default lock tuning (if unset):
+- `LockTTL = 3s`
+- `LockWaitTimeout = 2s`
+- `LockRetryInterval = 100ms`
+
+### 2.5 Error and Logging Design
+Error mapping:
+- invalid config/key -> `apperror.CodeInvalidInput`
+- cache miss -> `apperror.CodeNotFound`
+- lock wait timeout -> `apperror.CodeTimeout`
+- redis/serialization/deserialization/loader failures -> `apperror.CodeInternal`
+
+Logging approach:
+- logger source: `logger.Subsystem("cache")`
+- structured fields include: `operation`, `domain`, `entity`, `backend`, `error`, `key_hash`
+- redis failures are logged at warn/error based on path criticality
+
+---
+
+## 3. Interface Spec
+
+### 3.1 Public Struct Definitions
+
+```go
+// key.go
+type Key struct {
+    Domain     string
+    Entity     string
+    ID         string
+    Version    string
+    Qualifiers []string
+}
+```
+
+```go
+// config.go
+type Config struct {
+    Mode string // standalone | sentinel | cluster
+
+    Addrs      []string
+    Username   string
+    Password   string
+    DB         int
+    MasterName string
+
+    ServiceName string
+    KeyPrefix   string
+
+    DefaultTTL time.Duration
+
+    EnableStampedeProtection bool
+    LockTTL                  time.Duration
+    LockWaitTimeout          time.Duration
+    LockRetryInterval        time.Duration
+
+    DialTimeout  time.Duration
+    ReadTimeout  time.Duration
+    WriteTimeout time.Duration
+    PoolSize     int
+    MinIdleConns int
+}
+```
+
+### 3.2 Public Interface Definitions
+
+```go
+// cache.go
+type Cache interface {
+    Get(ctx context.Context, key Key, dest any) error
+    Set(ctx context.Context, key Key, value any, ttl time.Duration) error
+    Delete(ctx context.Context, keys ...Key) error
+    Exists(ctx context.Context, key Key) (bool, error)
+
+    GetOrSet(
+        ctx context.Context,
+        key Key,
+        dest any,
+        ttl time.Duration,
+        loader func(context.Context) (any, error),
+    ) error
+
+    Close() error
+}
+
+type HealthChecker interface {
+    Ping(ctx context.Context) error
+}
+```
+
+```go
+// codec.go
+type Codec interface {
+    Marshal(value any) ([]byte, error)
+    Unmarshal(data []byte, dest any) error
+    ContentType() string
+}
+```
+
+### 3.3 Public Constructor and Helpers
+
+```go
+// redis/redis.go
+func New(cfg cache.Config) (*Cache, error)
+```
+
+```go
+// key_builder.go
+func NewKeyBuilder(serviceName, keyPrefix string) (KeyBuilder, error)
+func ValidateKey(key Key) error
+```
+
+### 3.4 Method-Level Semantics
+
+#### `Get(ctx, key, dest) error`
+- Input:
+1. `dest` must be a writable target (typically pointer).
+- Output:
+1. `nil` on hit and successful decode.
+2. `CodeNotFound` for cache miss.
+3. `CodeInternal` for Redis or decode failure.
+
+#### `Set(ctx, key, value, ttl) error`
+- TTL resolution:
+1. if `ttl > 0`, use `ttl`
+2. else use `DefaultTTL`
+3. if resolved TTL `<= 0`, return `CodeInvalidInput`
+- Output:
+1. `nil` on success
+2. `CodeInternal` on serialize/redis failure
+
+#### `Delete(ctx, keys...) error`
+- No-op if no keys provided.
+- Returns validation error for invalid key.
+
+#### `Exists(ctx, key) (bool, error)`
+- Returns `true` if key exists, else `false`.
+- Redis failure returns `CodeInternal`.
+
+#### `GetOrSet(ctx, key, dest, ttl, loader) error`
+- Loader called only on miss or fallback conditions.
+- If loader succeeds, module tries to cache value and returns loader result even when cache set fails.
+- Loader failure returns `CodeInternal` wrapping loader cause.
+
+#### `Close() error`
+- Closes underlying Redis client.
+
+#### `Ping(ctx) error`
+- Returns `nil` if backend reachable.
+- Returns `CodeInternal` wrapped Redis error on failure.
+
+---
+
+## 4. Integration Spec
+
+### 4.1 Service Bootstrap Contract
+1. Parse service config/env into `cache.Config`.
+2. Create cache instance once at startup via `redis.New(cfg)`.
+3. Pass around as `cache.Cache` interface.
+4. Close at shutdown.
+
+### 4.2 Example Initialization
+
+```go
+cfg := cache.Config{
+    Mode:        "standalone",
+    Addrs:       []string{"localhost:6379"},
+    DB:          0,
+    ServiceName: "user-service",
+    DefaultTTL:  10 * time.Minute,
+
+    EnableStampedeProtection: true,
+    LockTTL:                  3 * time.Second,
+    LockWaitTimeout:          2 * time.Second,
+    LockRetryInterval:        100 * time.Millisecond,
+}
+
+c, err := redis.New(cfg)
+if err != nil {
+    return err
+}
+defer c.Close()
+```
+
+### 4.3 Example Read Path (`GetOrSet`)
+
+```go
+key := cache.Key{
+    Domain:  "user",
+    Entity:  "profile",
+    ID:      userID,
+    Version: "v1",
+}
+
+var user User
+err := c.GetOrSet(ctx, key, &user, 10*time.Minute, func(ctx context.Context) (any, error) {
+    return repo.GetByID(ctx, userID)
+})
+```
+
+### 4.4 Example Write Path (DB + Invalidate)
+
+```go
+if err := repo.Update(ctx, user); err != nil {
+    return err
+}
+
+key := cache.Key{Domain: "user", Entity: "profile", ID: user.ID, Version: "v1"}
+if err := c.Delete(ctx, key); err != nil {
+    // log and continue; DB remains source of truth
+}
+```
+
+### 4.5 Integration with Common Modules
+- `apperror` integration:
+1. cache module wraps validation/backend/codec/loader errors with standard codes.
+2. callers can use `apperror.CodeOf(err)` for handling logic.
+- `logger` integration:
+1. cache uses `logger.Subsystem("cache")`.
+2. structured logs are emitted on backend/lock/set degradation paths.
+
+### 4.6 Redis Mode Integration Details
+- `standalone`:
+1. use first `Addrs` entry as primary address.
+2. `DB` respected.
+- `sentinel`:
+1. requires `MasterName` + `Addrs` as sentinel nodes.
+2. `DB` respected.
+- `cluster`:
+1. requires one or more cluster node addresses.
+2. must use `DB=0`.
+
+### 4.7 Operational Guidelines
+- Use moderate TTLs based on data volatility.
+- Enable stampede protection for hot keys/high concurrency reads.
+- Avoid using cache as source of truth.
+- Treat Redis outages as degraded performance where business permits.

--- a/cache/CACHE_MODULE_SPEC.md
+++ b/cache/CACHE_MODULE_SPEC.md
@@ -30,6 +30,8 @@ The cache module provides a shared Redis-backed caching abstraction for all serv
 - Provide cache-aside read flow through `GetOrSet`.
 - Provide optional stampede protection lock for `GetOrSet` misses.
 - Provide Redis health check via `Ping`.
+- Provide baseline metrics for cache operability.
+- Support TTL jitter to reduce synchronized expiry bursts.
 
 ### 1.4 Non-Functional Requirements
 - All module errors must follow `apperror` conventions.
@@ -57,7 +59,6 @@ The cache module provides a shared Redis-backed caching abstraction for all serv
 5. `codec.go`: codec interface
 6. `json_codec.go`: default JSON codec
 7. `errors.go`: cache-level error helpers
-8. `noop.go`: no-op fallback cache
 - `cache/redis/`
 1. `redis.go`: Redis cache implementation
 2. `client.go`: mode-aware Redis client creation
@@ -66,7 +67,8 @@ The cache module provides a shared Redis-backed caching abstraction for all serv
 
 ### 2.2 Key Model and Generation
 Input key (service-level):
-- `Domain`, `Entity`, `ID`, `Version` are mandatory.
+- `Domain`, `Entity`, `ID` are mandatory.
+- `Version` is optional (defaults to `v1` when omitted/empty).
 - `Qualifiers` is optional.
 
 Generated key format:
@@ -74,6 +76,8 @@ Generated key format:
 
 Example:
 - Input: `{Domain:user, Entity:profile, ID:123, Version:v1}`
+- Output: `user-service:user:profile:123:v1`
+- Input without version: `{Domain:user, Entity:profile, ID:123}`
 - Output: `user-service:user:profile:123:v1`
 
 Normalization rules:
@@ -83,6 +87,7 @@ Normalization rules:
 - replace spaces with `-`
 - reject empty required fields after normalization
 - reject values containing internal `:` for required fields and qualifiers
+- reject values containing `__` for required fields and qualifiers (reserved internal namespace guard)
 - allowed characters per segment: `a-z`, `0-9`, `.`, `_`, `-`
 
 ### 2.3 Data Flow Design
@@ -98,6 +103,7 @@ Normalization rules:
 3. Resolve TTL:
 - use method TTL if `>0`
 - else use `Config.DefaultTTL`
+4. Apply TTL jitter when enabled (after TTL resolution, before Redis `SET`).
 4. Execute Redis `SET key value ttl`.
 
 #### GetOrSet Flow
@@ -117,9 +123,16 @@ Loader-to-destination rule:
 - The module serializes loader output with configured codec and deserializes into `dest`.
 - `dest` must be a non-nil writable pointer target.
 
+TTL rule:
+- `GetOrSet` uses the same TTL resolution as `Set`:
+1. method TTL wins when `ttl > 0`
+2. otherwise use `Config.DefaultTTL`
+3. if effective TTL `<= 0`, return `CodeInvalidInput`
+
 ### 2.4 Stampede Protection Design
 - Lock key shape:
-`<prefix>:lock:cache:<original-key-suffix>`
+`<prefix>:__cache_lock__:<original-key-suffix>`
+- `__cache_lock__` namespace is reserved for internal module use and must not be used by service business keys.
 - Acquire uses `SET NX PX` semantics via `SetNX` with TTL.
 - Lock token uses unique UUID.
 - Release uses Lua compare-and-delete for ownership-safe unlock.
@@ -138,6 +151,11 @@ Default lock tuning (if unset):
 - `LockWaitTimeout = 2s`
 - `LockRetryInterval = 100ms`
 
+Lock safety contract:
+- `LockTTL` must exceed the expected loader timeout.
+- Loader execution must run with a bounded context timeout shorter than `LockTTL`.
+- Recommended: keep safety margin between loader timeout and `LockTTL` (for example 20-30%).
+
 ### 2.5 Error and Logging Design
 Error mapping:
 - invalid config/key -> `apperror.CodeInvalidInput`
@@ -155,6 +173,18 @@ Graceful degradation contract (`GetOrSet`):
 - Lock acquire failure: log warn and fallback to loader.
 - Lock wait timeout: fallback to loader (current default behavior).
 - Cache `Set` failure after successful loader: log warn and still return loaded value (DB/source remains truth).
+
+### 2.6 Baseline Metrics
+The module should emit minimum metrics in Phase 1:
+- `cache_hit_total`
+- `cache_miss_total`
+- `cache_error_total`
+- basic latency for:
+1. `Get`
+2. `Set`
+3. loader execution in `GetOrSet`
+
+Metric labels should remain minimal in Phase 1 (`operation`, `result`, `service`).
 
 ---
 
@@ -188,6 +218,8 @@ type Config struct {
     KeyPrefix   string
 
     DefaultTTL time.Duration
+    EnableTTLJitter bool
+    TTLJitterPct    float64 // for example 0.10 => +/-10% jitter, valid range [0.0, 0.5]
 
     EnableStampedeProtection bool
     LockTTL                  time.Duration
@@ -265,6 +297,7 @@ func ValidateKey(key Key) error
 1. if `ttl > 0`, use `ttl`
 2. else use `DefaultTTL`
 3. if resolved TTL `<= 0`, return `CodeInvalidInput`
+4. if TTL jitter is enabled, apply jitter before write
 - Output:
 1. `nil` on success
 2. `CodeInternal` on serialize/redis failure
@@ -282,6 +315,7 @@ func ValidateKey(key Key) error
 - Loader called only on miss or fallback conditions.
 - If loader succeeds, module tries to cache value and returns loader result even when cache set fails.
 - Loader failure returns `CodeInternal` wrapping loader cause.
+- TTL handling is identical to `Set` (same resolution and validation rules).
 
 #### `Close() error`
 - Closes underlying Redis client.
@@ -319,6 +353,20 @@ Health-check interface note:
 1. `Set` uses method TTL when `ttl > 0`.
 2. Otherwise uses `DefaultTTL`.
 3. If effective TTL is not positive, return `CodeInvalidInput`.
+4. `GetOrSet` follows the exact same TTL rules.
+- TTL ownership:
+1. The library enforces TTL mechanics and validation.
+2. Service teams own the business TTL decision per data type/use case.
+- Non-expiring keys:
+1. Currently does not allow immortal cache entries.
+2. If effective TTL is not positive, write must fail with `CodeInvalidInput`.
+- TTL jitter:
+1. Optional.
+2. Applies only after effective TTL is resolved.
+3. Should keep TTL positive after jitter.
+4. `TTLJitterPct` valid range: `0.0 <= TTLJitterPct <= 0.5`.
+5. Effective TTL should be calculated as: `effectiveTTL * (1 ± random*jitterPct)`.
+6. Final jittered TTL must be clamped to a positive duration.
 - Timeout defaults (when unset):
 1. `DialTimeout = 2s`
 2. `ReadTimeout = 500ms`
@@ -412,20 +460,21 @@ if err := c.Delete(ctx, key); err != nil {
 - Enable stampede protection for hot keys/high concurrency reads.
 - Avoid using cache as source of truth.
 - Treat Redis outages as degraded performance where business permits.
+- Keep TTL jitter enabled for high-cardinality/hot domains to reduce synchronized expirations.
+- Redis deployment must remain private/internal network only in current phase.
+- Redis must not be directly reachable from public internet/external networks.
 
 ---
 
 ## 5. Future Scope
 
 ### 5.1 Observability Enhancements
-- Define a standard cache metrics contract:
+- Expand baseline metrics into a richer observability contract:
 1. `cache_get_total`
-2. `cache_hit_total`
-3. `cache_miss_total`
-4. `cache_set_total`
-5. `cache_delete_total`
-6. `cache_error_total`
-7. latency histograms for `get`, `set`, and `loader`
+2. `cache_set_total`
+3. `cache_delete_total`
+4. per-operation latency histograms with finer buckets
+5. lock-acquire/lock-timeout counters for stampede analysis
 - Add tracing hooks for cache spans and loader spans.
 
 ### 5.2 Resilience and Fallback Controls
@@ -438,20 +487,26 @@ if err := c.Delete(ctx, key); err != nil {
 - Support pluggable codecs beyond JSON (for example MsgPack/Protobuf).
 - Add optional payload compression for large cache values.
 - Add optional encryption for sensitive cache payloads.
+- Add Redis TLS transport support for in-transit encryption and stronger network security.
 
 ### 5.4 TTL Strategy Improvements
-- Add TTL jitter to avoid synchronized expiration bursts.
 - Add policy-driven TTL profiles by data category (profile/config/search/aggregate).
 
-### 5.5 Invalidation and Key Management
+### 5.5 Negative Caching (Future)
+- Add optional negative caching policy for `NOT_FOUND` loader results.
+- Support short configurable TTL for negative entries.
+- Keep feature opt-in and scoped to explicitly allowed domains/entities.
+- Ensure negative cache entries are distinguishable from normal cached payloads.
+
+### 5.6 Invalidation and Key Management
 - Add first-class support for batch/group invalidation patterns.
 - Define event-driven invalidation integration patterns for write-heavy domains.
 
-### 5.6 Operational and Compliance Guidance
+### 5.7 Operational and Compliance Guidance
 - Add service integration checklist for rollout readiness.
 - Add conformance test guidelines to validate service-side usage against this spec.
 
-### 5.7 Advanced Redis Operations (Optional)
+### 5.8 Advanced Redis Operations (Optional)
 - Add bulk APIs for high-throughput paths:
 1. `MGet(ctx, keys...)`
 2. `MSet(ctx, items, ttl)` (or equivalent batch set contract)

--- a/cache/README.md
+++ b/cache/README.md
@@ -1,0 +1,52 @@
+# Cache Module
+
+Common Redis cache module for Go services.
+
+## Features
+
+- Structured key model (`cache.Key`) with opaque final key generation.
+- Shared prefixing by service name/key prefix.
+- `Get`, `Set`, `Delete`, `Exists`, and `GetOrSet` APIs.
+- Redis modes: `standalone`, `sentinel`, `cluster`.
+- Optional stampede protection lock flow inside `GetOrSet`.
+- Common error wrapping via `apperror`.
+- Common logging via `logger`.
+
+## Install
+
+```bash
+go get github.com/routerarchitects/ra-common-mods/cache
+```
+
+## Basic usage
+
+```go
+cfg := cache.Config{
+	Mode:        "standalone",
+	Addrs:       []string{"localhost:6379"},
+	DB:          0,
+	ServiceName: "user-service",
+	DefaultTTL:  10 * time.Minute,
+}
+
+c, err := redis.New(cfg)
+if err != nil {
+	return err
+}
+defer c.Close()
+
+key := cache.Key{Domain: "user", Entity: "profile", ID: "123"}
+
+var user User
+if err := c.GetOrSet(ctx, key, &user, 10*time.Minute, func(ctx context.Context) (any, error) {
+	return repo.GetUser(ctx, "123")
+}); err != nil {
+	return err
+}
+```
+
+## Notes
+
+- Services should never build raw Redis keys directly.
+- In cluster mode, `DB` must be `0`.
+- Locking is internal to `GetOrSet`; plain `Get/Set/Delete/Exists` do not lock.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/routerarchitects/ra-common-mods/apperror"
+)
+
+type Key struct {
+	Domain     string
+	Entity     string
+	ID         string
+	Version    string
+	Qualifiers []string
+}
+
+type Config struct {
+	Mode string
+
+	Addrs      []string
+	Username   string
+	Password   string
+	DB         int
+	MasterName string
+
+	ServiceName string
+	KeyPrefix   string
+
+	DefaultTTL      time.Duration
+	EnableTTLJitter bool
+	TTLJitterPct    float64
+
+	EnableStampedeProtection bool
+	LockTTL                  time.Duration
+	LockWaitTimeout          time.Duration
+	LockRetryInterval        time.Duration
+
+	DialTimeout  time.Duration
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+	PoolSize     int
+	MinIdleConns int
+}
+
+type Cache interface {
+	Get(ctx context.Context, key Key, dest any) error
+	Set(ctx context.Context, key Key, value any, ttl time.Duration) error
+	Delete(ctx context.Context, keys ...Key) error
+	Exists(ctx context.Context, key Key) (bool, error)
+	GetOrSet(ctx context.Context, key Key, dest any, ttl time.Duration, loader func(context.Context) (any, error)) error
+	Close() error
+}
+
+type HealthChecker interface {
+	Ping(ctx context.Context) error
+}
+
+type Codec interface {
+	Marshal(value any) ([]byte, error)
+	Unmarshal(data []byte, dest any) error
+	ContentType() string
+}
+
+type JSONCodec struct{}
+
+func (JSONCodec) Marshal(value any) ([]byte, error) {
+	return json.Marshal(value)
+}
+
+func (JSONCodec) Unmarshal(data []byte, dest any) error {
+	return json.Unmarshal(data, dest)
+}
+
+func (JSONCodec) ContentType() string {
+	return "application/json"
+}
+
+func errInvalidConfig(msg string, meta map[string]any) error {
+	return apperror.WrapWithMeta(apperror.CodeInvalidInput, "cache invalid config", errors.New(msg), meta)
+}
+
+func errInvalidKey(msg string, meta map[string]any) error {
+	return apperror.WrapWithMeta(apperror.CodeInvalidInput, "cache invalid key", errors.New(msg), meta)
+}

--- a/cache/go.mod
+++ b/cache/go.mod
@@ -1,0 +1,15 @@
+module github.com/routerarchitects/ra-common-mods/cache
+
+go 1.25.0
+
+require (
+	github.com/google/uuid v1.6.0
+	github.com/redis/go-redis/v9 v9.17.0
+	github.com/routerarchitects/ra-common-mods/apperror v0.2.0
+	github.com/routerarchitects/ra-common-mods/logger v0.1.0
+)
+
+require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+)

--- a/cache/go.sum
+++ b/cache/go.sum
@@ -1,0 +1,16 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/redis/go-redis/v9 v9.17.0 h1:K6E+ZlYN95KSMmZeEQPbU/c++wfmEvfFB17yEAq/VhM=
+github.com/redis/go-redis/v9 v9.17.0/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
+github.com/routerarchitects/ra-common-mods/apperror v0.2.0 h1:/otTh1Z1VTT0eSdKU0uoPCoquhbRm/lyr36QI09V2L0=
+github.com/routerarchitects/ra-common-mods/apperror v0.2.0/go.mod h1:tCSnjL1XnUDhxt4iIQsPOeecEyDhtpBbUyj+aMAkF2A=
+github.com/routerarchitects/ra-common-mods/logger v0.1.0 h1:LQdbIRtK4bgtNZG5Ez6qfCrm4GKQP2ZG2HWItAR72pk=
+github.com/routerarchitects/ra-common-mods/logger v0.1.0/go.mod h1:UtabkmNZMfPaaM1Zzzt3RScSfCME3qnyKXeCRBH1LrM=

--- a/cache/json_codec_test.go
+++ b/cache/json_codec_test.go
@@ -1,0 +1,26 @@
+package cache
+
+import "testing"
+
+type sample struct {
+	Name string `json:"name"`
+}
+
+func TestJSONCodecRoundTrip(t *testing.T) {
+	codec := JSONCodec{}
+	in := sample{Name: "alice"}
+	b, err := codec.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	var out sample
+	if err := codec.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if out.Name != "alice" {
+		t.Fatalf("unexpected value: %+v", out)
+	}
+	if codec.ContentType() != "application/json" {
+		t.Fatalf("unexpected content type: %s", codec.ContentType())
+	}
+}

--- a/cache/key_builder.go
+++ b/cache/key_builder.go
@@ -1,0 +1,127 @@
+package cache
+
+import (
+	"strings"
+)
+
+const defaultKeyVersion = "v1"
+
+type KeyBuilder struct {
+	prefix string
+}
+
+func NewKeyBuilder(serviceName, keyPrefix string) (KeyBuilder, error) {
+	prefix := normalizeSegment(keyPrefix)
+	if prefix == "" {
+		prefix = normalizeSegment(serviceName)
+	}
+	if prefix == "" {
+		return KeyBuilder{}, errInvalidConfig("service name or key prefix must be set", nil)
+	}
+	if err := validateSegment(prefix, "prefix"); err != nil {
+		return KeyBuilder{}, err
+	}
+	return KeyBuilder{prefix: prefix}, nil
+}
+
+func (b KeyBuilder) Build(key Key) (string, error) {
+	if err := ValidateKey(key); err != nil {
+		return "", err
+	}
+
+	segments := []string{
+		b.prefix,
+		normalizeSegment(key.Domain),
+		normalizeSegment(key.Entity),
+		normalizeSegment(key.ID),
+	}
+
+	for _, q := range key.Qualifiers {
+		s := normalizeSegment(q)
+		if s == "" {
+			continue
+		}
+		segments = append(segments, s)
+	}
+	segments = append(segments, resolveVersion(key.Version))
+	return strings.Join(segments, ":"), nil
+}
+
+func (b KeyBuilder) LockKey(key Key) (string, error) {
+	full, err := b.Build(key)
+	if err != nil {
+		return "", err
+	}
+	return b.prefix + ":__cache_lock__:" + strings.TrimPrefix(full, b.prefix+":"), nil
+}
+
+func ValidateKey(key Key) error {
+	domain := normalizeSegment(key.Domain)
+	entity := normalizeSegment(key.Entity)
+	id := normalizeSegment(key.ID)
+	version := resolveVersion(key.Version)
+
+	if domain == "" {
+		return errInvalidKey("domain is required", map[string]any{"field": "domain"})
+	}
+	if entity == "" {
+		return errInvalidKey("entity is required", map[string]any{"field": "entity"})
+	}
+	if id == "" {
+		return errInvalidKey("id is required", map[string]any{"field": "id"})
+	}
+	if err := validateSegment(domain, "domain"); err != nil {
+		return err
+	}
+	if err := validateSegment(entity, "entity"); err != nil {
+		return err
+	}
+	if err := validateSegment(id, "id"); err != nil {
+		return err
+	}
+	if err := validateSegment(version, "version"); err != nil {
+		return err
+	}
+	for i, q := range key.Qualifiers {
+		segment := normalizeSegment(q)
+		if segment == "" {
+			continue
+		}
+		if err := validateSegment(segment, "qualifiers"); err != nil {
+			return errInvalidKey("invalid qualifier segment", map[string]any{"field": "qualifiers", "index": i, "value": segment, "cause": err.Error()})
+		}
+	}
+	return nil
+}
+
+func normalizeSegment(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, ":")
+	s = strings.ReplaceAll(s, " ", "-")
+	s = strings.ToLower(s)
+	return s
+}
+
+func resolveVersion(version string) string {
+	v := normalizeSegment(version)
+	if v == "" {
+		return defaultKeyVersion
+	}
+	return v
+}
+
+func validateSegment(segment, field string) error {
+	if strings.Contains(segment, ":") {
+		return errInvalidKey("invalid cache key segment", map[string]any{"field": field, "reason": "contains colon"})
+	}
+	if strings.Contains(segment, "__") {
+		return errInvalidKey("invalid cache key segment", map[string]any{"field": field, "reason": "contains reserved double underscore"})
+	}
+	for _, r := range segment {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '.' || r == '_' || r == '-' {
+			continue
+		}
+		return errInvalidKey("invalid cache key segment", map[string]any{"field": field, "reason": "contains unsupported character"})
+	}
+	return nil
+}

--- a/cache/key_builder_test.go
+++ b/cache/key_builder_test.go
@@ -1,0 +1,77 @@
+package cache
+
+import "testing"
+
+func TestBuildKey(t *testing.T) {
+	b, err := NewKeyBuilder("User-Service", "")
+	if err != nil {
+		t.Fatalf("NewKeyBuilder failed: %v", err)
+	}
+	key, err := b.Build(Key{Domain: "user", Entity: "profile", ID: "123", Version: "v1"})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if key != "user-service:user:profile:123:v1" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+func TestBuildKeyDefaultsVersion(t *testing.T) {
+	b, err := NewKeyBuilder("User-Service", "")
+	if err != nil {
+		t.Fatalf("NewKeyBuilder failed: %v", err)
+	}
+	key, err := b.Build(Key{Domain: "user", Entity: "profile", ID: "123"})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if key != "user-service:user:profile:123:v1" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+}
+
+func TestBuildKeyWithQualifiersAndLockKey(t *testing.T) {
+	b, err := NewKeyBuilder("catalog-service", "")
+	if err != nil {
+		t.Fatalf("NewKeyBuilder failed: %v", err)
+	}
+	key, err := b.Build(Key{Domain: "product", Entity: "recommendation", ID: "123", Qualifiers: []string{"region", "IN", "lang", "en"}, Version: "v1"})
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if key != "catalog-service:product:recommendation:123:region:in:lang:en:v1" {
+		t.Fatalf("unexpected key: %s", key)
+	}
+
+	lock, err := b.LockKey(Key{Domain: "product", Entity: "recommendation", ID: "123", Version: "v1"})
+	if err != nil {
+		t.Fatalf("LockKey failed: %v", err)
+	}
+	if lock != "catalog-service:__cache_lock__:product:recommendation:123:v1" {
+		t.Fatalf("unexpected lock key: %s", lock)
+	}
+}
+
+func TestValidateKey(t *testing.T) {
+	if err := ValidateKey(Key{Domain: "", Entity: "b", ID: "1", Version: "v1"}); err == nil {
+		t.Fatal("expected invalid domain")
+	}
+	if err := ValidateKey(Key{Domain: "a", Entity: "", ID: "1", Version: "v1"}); err == nil {
+		t.Fatal("expected invalid entity")
+	}
+	if err := ValidateKey(Key{Domain: "a", Entity: "b", ID: "", Version: "v1"}); err == nil {
+		t.Fatal("expected invalid id")
+	}
+	if err := ValidateKey(Key{Domain: "a:b", Entity: "b", ID: "1", Version: "v1"}); err == nil {
+		t.Fatal("expected invalid domain with colon")
+	}
+	if err := ValidateKey(Key{Domain: "a__b", Entity: "b", ID: "1", Version: "v1"}); err == nil {
+		t.Fatal("expected invalid domain with double underscore")
+	}
+	if err := ValidateKey(Key{Domain: "a", Entity: "b", ID: "1", Version: "v1", Qualifiers: []string{"ok", "ba:d"}}); err == nil {
+		t.Fatal("expected invalid qualifier with colon")
+	}
+	if err := ValidateKey(Key{Domain: "a", Entity: "b", ID: "1", Version: "v1", Qualifiers: []string{"bad__value"}}); err == nil {
+		t.Fatal("expected invalid qualifier with double underscore")
+	}
+}

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -104,15 +104,13 @@ func (c *Cache) Set(ctx context.Context, key cache.Key, value any, ttl time.Dura
 		incError()
 		return apperror.Wrap(apperror.CodeInternal, "cache serialization failed", err)
 	}
-	if ttl <= 0 {
-		ttl = c.cfg.DefaultTTL
-	}
-	if ttl <= 0 {
+	effectiveTTL, err := c.resolveEffectiveTTL(ttl)
+	if err != nil {
 		incError()
-		return apperror.New(apperror.CodeInvalidInput, "cache ttl must be positive")
+		return err
 	}
-	ttl = applyTTLJitter(ttl, c.cfg.EnableTTLJitter, c.cfg.TTLJitterPct)
-	if err := c.client.Set(ctx, redisKey, payload, ttl).Err(); err != nil {
+	effectiveTTL = applyTTLJitter(effectiveTTL, c.cfg.EnableTTLJitter, c.cfg.TTLJitterPct)
+	if err := c.client.Set(ctx, redisKey, payload, effectiveTTL).Err(); err != nil {
 		incError()
 		return wrapRedisError("set", err)
 	}
@@ -153,6 +151,10 @@ func (c *Cache) GetOrSet(ctx context.Context, key cache.Key, dest any, ttl time.
 	if loader == nil {
 		incError()
 		return apperror.New(apperror.CodeInvalidInput, "cache loader is required")
+	}
+	if _, err := c.resolveEffectiveTTL(ttl); err != nil {
+		incError()
+		return err
 	}
 
 	redisKey, err := c.builder.Build(key)
@@ -303,6 +305,17 @@ func applyTTLJitter(ttl time.Duration, enabled bool, jitterPct float64) time.Dur
 	return jittered
 }
 
+func (c *Cache) resolveEffectiveTTL(ttl time.Duration) (time.Duration, error) {
+	effective := ttl
+	if effective <= 0 {
+		effective = c.cfg.DefaultTTL
+	}
+	if effective <= 0 {
+		return 0, apperror.New(apperror.CodeInvalidInput, "cache ttl must be positive")
+	}
+	return effective, nil
+}
+
 func newClient(cfg cache.Config) (red.UniversalClient, error) {
 	switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
 	case "", "standalone":
@@ -421,12 +434,14 @@ func (c *Cache) waitForFill(ctx context.Context, key string, dest any, started t
 		} else if apperror.CodeOf(err) != apperror.CodeNotFound {
 			return err
 		}
-		timer := time.NewTimer(c.cfg.LockRetryInterval)
+		retryInterval := c.cfg.LockRetryInterval
+		if retryInterval <= 0 {
+			retryInterval = 100 * time.Millisecond
+		}
+		timer := time.NewTimer(retryInterval)
 		select {
 		case <-ctx.Done():
-			if !timer.Stop() {
-				<-timer.C
-			}
+			timer.Stop()
 			return ctx.Err()
 		case <-timer.C:
 		}

--- a/cache/redis/redis.go
+++ b/cache/redis/redis.go
@@ -1,0 +1,462 @@
+package redis
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"expvar"
+	"log/slog"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	red "github.com/redis/go-redis/v9"
+	"github.com/routerarchitects/ra-common-mods/apperror"
+	"github.com/routerarchitects/ra-common-mods/cache"
+	"github.com/routerarchitects/ra-common-mods/logger"
+)
+
+type Cache struct {
+	cfg     cache.Config
+	client  red.UniversalClient
+	codec   cache.Codec
+	builder cache.KeyBuilder
+	log     *slog.Logger
+}
+
+var (
+	cacheHitTotal   = expvar.NewInt("cache_hit_total")
+	cacheMissTotal  = expvar.NewInt("cache_miss_total")
+	cacheErrorTotal = expvar.NewInt("cache_error_total")
+
+	cacheGetLatencyMsTotal    = expvar.NewInt("cache_get_latency_ms_total")
+	cacheSetLatencyMsTotal    = expvar.NewInt("cache_set_latency_ms_total")
+	cacheLoaderLatencyMsTotal = expvar.NewInt("cache_loader_latency_ms_total")
+)
+
+const unlockScript = `if redis.call("GET", KEYS[1]) == ARGV[1] then return redis.call("DEL", KEYS[1]) else return 0 end`
+
+func New(cfg cache.Config) (cache.Cache, error) {
+	cfg = applyDefaults(cfg)
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, err
+	}
+	builder, err := cache.NewKeyBuilder(cfg.ServiceName, cfg.KeyPrefix)
+	if err != nil {
+		return nil, err
+	}
+	client, err := newClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &Cache{
+		cfg:     cfg,
+		client:  client,
+		codec:   cache.JSONCodec{},
+		builder: builder,
+		log:     logger.Subsystem("cache"),
+	}, nil
+}
+
+func (c *Cache) Get(ctx context.Context, key cache.Key, dest any) error {
+	redisKey, err := c.builder.Build(key)
+	if err != nil {
+		return err
+	}
+	return c.getByStringKey(ctx, redisKey, dest)
+}
+
+func (c *Cache) getByStringKey(ctx context.Context, redisKey string, dest any) error {
+	start := time.Now()
+	defer observeGetLatency(start)
+
+	payload, err := c.client.Get(ctx, redisKey).Bytes()
+	if err != nil {
+		if errors.Is(err, red.Nil) {
+			incMiss()
+			return apperror.New(apperror.CodeNotFound, "cache miss")
+		}
+		incError()
+		return wrapRedisError("get", err)
+	}
+	if err := c.codec.Unmarshal(payload, dest); err != nil {
+		incError()
+		return apperror.Wrap(apperror.CodeInternal, "cache deserialization failed", err)
+	}
+	incHit()
+	return nil
+}
+
+func (c *Cache) Set(ctx context.Context, key cache.Key, value any, ttl time.Duration) error {
+	start := time.Now()
+	defer observeSetLatency(start)
+
+	redisKey, err := c.builder.Build(key)
+	if err != nil {
+		incError()
+		return err
+	}
+	payload, err := c.codec.Marshal(value)
+	if err != nil {
+		incError()
+		return apperror.Wrap(apperror.CodeInternal, "cache serialization failed", err)
+	}
+	if ttl <= 0 {
+		ttl = c.cfg.DefaultTTL
+	}
+	if ttl <= 0 {
+		incError()
+		return apperror.New(apperror.CodeInvalidInput, "cache ttl must be positive")
+	}
+	ttl = applyTTLJitter(ttl, c.cfg.EnableTTLJitter, c.cfg.TTLJitterPct)
+	if err := c.client.Set(ctx, redisKey, payload, ttl).Err(); err != nil {
+		incError()
+		return wrapRedisError("set", err)
+	}
+	return nil
+}
+
+func (c *Cache) Delete(ctx context.Context, keys ...cache.Key) error {
+	if len(keys) == 0 {
+		return nil
+	}
+	redisKeys := make([]string, 0, len(keys))
+	for _, key := range keys {
+		redisKey, err := c.builder.Build(key)
+		if err != nil {
+			return err
+		}
+		redisKeys = append(redisKeys, redisKey)
+	}
+	if err := c.client.Del(ctx, redisKeys...).Err(); err != nil {
+		return wrapRedisError("delete", err)
+	}
+	return nil
+}
+
+func (c *Cache) Exists(ctx context.Context, key cache.Key) (bool, error) {
+	redisKey, err := c.builder.Build(key)
+	if err != nil {
+		return false, err
+	}
+	count, err := c.client.Exists(ctx, redisKey).Result()
+	if err != nil {
+		return false, wrapRedisError("exists", err)
+	}
+	return count > 0, nil
+}
+
+func (c *Cache) GetOrSet(ctx context.Context, key cache.Key, dest any, ttl time.Duration, loader func(context.Context) (any, error)) error {
+	if loader == nil {
+		incError()
+		return apperror.New(apperror.CodeInvalidInput, "cache loader is required")
+	}
+
+	redisKey, err := c.builder.Build(key)
+	if err != nil {
+		incError()
+		return err
+	}
+	if err := c.getByStringKey(ctx, redisKey, dest); err == nil {
+		return nil
+	} else if apperror.CodeOf(err) != apperror.CodeNotFound {
+		c.log.WarnContext(ctx, "cache get failed, falling back to loader", "operation", "get", "key_hash", hashKey(redisKey), "error", err)
+		return c.loadAndFill(ctx, key, dest, ttl, loader)
+	}
+
+	if !c.cfg.EnableStampedeProtection {
+		return c.loadAndFill(ctx, key, dest, ttl, loader)
+	}
+
+	lockKey, err := c.builder.LockKey(key)
+	if err != nil {
+		return err
+	}
+	started := time.Now()
+	token, acquired, err := c.tryAcquireLock(ctx, lockKey)
+	if err != nil {
+		c.log.WarnContext(ctx, "cache lock acquire failed, using loader", "operation", "lock", "key_hash", hashKey(redisKey), "error", err)
+		return c.loadAndFill(ctx, key, dest, ttl, loader)
+	}
+	if acquired {
+		defer func() {
+			if releaseErr := c.releaseLock(context.Background(), lockKey, token); releaseErr != nil {
+				c.log.Error("cache lock release failed", "operation", "unlock", "key_hash", hashKey(redisKey), "error", releaseErr)
+			}
+		}()
+		if err := c.getByStringKey(ctx, redisKey, dest); err == nil {
+			return nil
+		}
+		return c.loadAndFill(ctx, key, dest, ttl, loader)
+	}
+
+	if err := c.waitForFill(ctx, redisKey, dest, started); err == nil {
+		return nil
+	}
+	return c.loadAndFill(ctx, key, dest, ttl, loader)
+}
+
+func (c *Cache) loadAndFill(ctx context.Context, key cache.Key, dest any, ttl time.Duration, loader func(context.Context) (any, error)) error {
+	if loader == nil {
+		incError()
+		return apperror.New(apperror.CodeInvalidInput, "cache loader is required")
+	}
+
+	loaderCtx, cancel, err := c.loaderContext(ctx)
+	if err != nil {
+		incError()
+		return err
+	}
+	defer cancel()
+
+	loaderStart := time.Now()
+	value, err := loader(loaderCtx)
+	observeLoaderLatency(loaderStart)
+	if err != nil {
+		incError()
+		return apperror.Wrap(apperror.CodeInternal, "cache loader failed", err)
+	}
+	if err := c.Set(ctx, key, value, ttl); err != nil {
+		// Invalid input (for example non-positive effective TTL) should not silently succeed.
+		if apperror.CodeOf(err) == apperror.CodeInvalidInput {
+			return err
+		}
+		c.log.WarnContext(ctx, "cache set failed after loader", "operation", "set", "domain", key.Domain, "entity", key.Entity, "error", err)
+	}
+	payload, err := c.codec.Marshal(value)
+	if err != nil {
+		incError()
+		return apperror.Wrap(apperror.CodeInternal, "cache serialization failed", err)
+	}
+	if err := c.codec.Unmarshal(payload, dest); err != nil {
+		incError()
+		return apperror.Wrap(apperror.CodeInternal, "cache deserialization failed", err)
+	}
+	return nil
+}
+
+func (c *Cache) Close() error {
+	return c.client.Close()
+}
+
+func (c *Cache) Ping(ctx context.Context) error {
+	if err := c.client.Ping(ctx).Err(); err != nil {
+		return wrapRedisError("ping", err)
+	}
+	return nil
+}
+
+func validateConfig(cfg cache.Config) error {
+	if cfg.ServiceName == "" && cfg.KeyPrefix == "" {
+		return cacheErrInvalidConfig("service name or key prefix is required")
+	}
+	if len(cfg.Addrs) == 0 {
+		return cacheErrInvalidConfig("at least one redis address is required")
+	}
+	if cfg.TTLJitterPct < 0 || cfg.TTLJitterPct > 0.5 {
+		return cacheErrInvalidConfig("ttl jitter percent must be in range [0.0, 0.5]")
+	}
+	if cfg.EnableStampedeProtection && cfg.LockTTL <= time.Millisecond {
+		return cacheErrInvalidConfig("lock ttl must be greater than 1ms when stampede protection is enabled")
+	}
+	return nil
+}
+
+func applyDefaults(cfg cache.Config) cache.Config {
+	if cfg.LockTTL <= 0 {
+		cfg.LockTTL = 3 * time.Second
+	}
+	if cfg.LockWaitTimeout <= 0 {
+		cfg.LockWaitTimeout = 2 * time.Second
+	}
+	if cfg.LockRetryInterval <= 0 {
+		cfg.LockRetryInterval = 100 * time.Millisecond
+	}
+	return cfg
+}
+
+func wrapRedisError(operation string, err error) error {
+	return apperror.WrapWithMeta(apperror.CodeInternal, "cache redis command failed", err, map[string]any{"operation": operation, "backend": "redis"})
+}
+
+func cacheErrInvalidConfig(msg string) error {
+	return apperror.Wrap(apperror.CodeInvalidInput, "cache invalid config", errors.New(msg))
+}
+
+func hashKey(k string) string {
+	sum := sha256.Sum256([]byte(k))
+	return hex.EncodeToString(sum[:8])
+}
+
+func applyTTLJitter(ttl time.Duration, enabled bool, jitterPct float64) time.Duration {
+	if !enabled || jitterPct <= 0 {
+		return ttl
+	}
+	factor := 1 + ((rand.Float64()*2 - 1) * jitterPct)
+	jittered := time.Duration(float64(ttl) * factor)
+	if jittered <= 0 {
+		return time.Millisecond
+	}
+	return jittered
+}
+
+func newClient(cfg cache.Config) (red.UniversalClient, error) {
+	switch strings.ToLower(strings.TrimSpace(cfg.Mode)) {
+	case "", "standalone":
+		if len(cfg.Addrs) == 0 {
+			return nil, cacheErrInvalidConfig("addrs are required")
+		}
+		return red.NewClient(&red.Options{
+			Addr:         cfg.Addrs[0],
+			Username:     cfg.Username,
+			Password:     cfg.Password,
+			DB:           cfg.DB,
+			DialTimeout:  nonZero(cfg.DialTimeout, 2*time.Second),
+			ReadTimeout:  nonZero(cfg.ReadTimeout, 500*time.Millisecond),
+			WriteTimeout: nonZero(cfg.WriteTimeout, 500*time.Millisecond),
+			PoolSize:     cfg.PoolSize,
+			MinIdleConns: cfg.MinIdleConns,
+		}), nil
+	case "sentinel":
+		if len(cfg.Addrs) == 0 || strings.TrimSpace(cfg.MasterName) == "" {
+			return nil, cacheErrInvalidConfig("sentinel mode requires addrs and master name")
+		}
+		return red.NewFailoverClient(&red.FailoverOptions{
+			MasterName:    cfg.MasterName,
+			SentinelAddrs: cfg.Addrs,
+			Username:      cfg.Username,
+			Password:      cfg.Password,
+			DB:            cfg.DB,
+			DialTimeout:   nonZero(cfg.DialTimeout, 2*time.Second),
+			ReadTimeout:   nonZero(cfg.ReadTimeout, 500*time.Millisecond),
+			WriteTimeout:  nonZero(cfg.WriteTimeout, 500*time.Millisecond),
+			PoolSize:      cfg.PoolSize,
+			MinIdleConns:  cfg.MinIdleConns,
+		}), nil
+	case "cluster":
+		if len(cfg.Addrs) == 0 {
+			return nil, cacheErrInvalidConfig("cluster mode requires addrs")
+		}
+		if cfg.DB != 0 {
+			return nil, cacheErrInvalidConfig("cluster mode requires db=0")
+		}
+		return red.NewClusterClient(&red.ClusterOptions{
+			Addrs:        cfg.Addrs,
+			Username:     cfg.Username,
+			Password:     cfg.Password,
+			DialTimeout:  nonZero(cfg.DialTimeout, 2*time.Second),
+			ReadTimeout:  nonZero(cfg.ReadTimeout, 500*time.Millisecond),
+			WriteTimeout: nonZero(cfg.WriteTimeout, 500*time.Millisecond),
+			PoolSize:     cfg.PoolSize,
+			MinIdleConns: cfg.MinIdleConns,
+		}), nil
+	default:
+		return nil, cacheErrInvalidConfig("unsupported cache mode")
+	}
+}
+
+func nonZero(value, fallback time.Duration) time.Duration {
+	if value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+func observeGetLatency(start time.Time) {
+	cacheGetLatencyMsTotal.Add(time.Since(start).Milliseconds())
+}
+
+func observeSetLatency(start time.Time) {
+	cacheSetLatencyMsTotal.Add(time.Since(start).Milliseconds())
+}
+
+func observeLoaderLatency(start time.Time) {
+	cacheLoaderLatencyMsTotal.Add(time.Since(start).Milliseconds())
+}
+
+func incHit() {
+	cacheHitTotal.Add(1)
+}
+
+func incMiss() {
+	cacheMissTotal.Add(1)
+}
+
+func incError() {
+	cacheErrorTotal.Add(1)
+}
+
+func (c *Cache) tryAcquireLock(ctx context.Context, lockKey string) (string, bool, error) {
+	token := uuid.NewString()
+	ok, err := c.client.SetNX(ctx, lockKey, token, c.cfg.LockTTL).Result()
+	if err != nil {
+		return "", false, apperror.Wrap(apperror.CodeInternal, "cache lock acquire failed", err)
+	}
+	return token, ok, nil
+}
+
+func (c *Cache) releaseLock(ctx context.Context, lockKey, token string) error {
+	if token == "" {
+		return nil
+	}
+	if err := c.client.Eval(ctx, unlockScript, []string{lockKey}, token).Err(); err != nil && err != red.Nil {
+		return apperror.Wrap(apperror.CodeInternal, "cache lock release failed", err)
+	}
+	return nil
+}
+
+func (c *Cache) waitForFill(ctx context.Context, key string, dest any, started time.Time) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if c.cfg.LockWaitTimeout > 0 && time.Since(started) > c.cfg.LockWaitTimeout {
+			return apperror.New(apperror.CodeTimeout, "cache lock wait timeout")
+		}
+		if err := c.getByStringKey(ctx, key, dest); err == nil {
+			return nil
+		} else if apperror.CodeOf(err) != apperror.CodeNotFound {
+			return err
+		}
+		timer := time.NewTimer(c.cfg.LockRetryInterval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (c *Cache) loaderContext(parent context.Context) (context.Context, context.CancelFunc, error) {
+	if !c.cfg.EnableStampedeProtection || c.cfg.LockTTL <= 0 {
+		return parent, func() {}, nil
+	}
+
+	// Keep loader bounded below lock TTL with safety margin.
+	safety := c.cfg.LockTTL / 5 // 20%
+	if safety < 50*time.Millisecond {
+		safety = 50 * time.Millisecond
+	}
+	loaderBudget := c.cfg.LockTTL - safety
+	if loaderBudget <= 0 {
+		return nil, nil, apperror.New(apperror.CodeInvalidInput, "lock ttl too small for bounded loader timeout")
+	}
+
+	if deadline, ok := parent.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return parent, func() {}, nil
+		}
+		if remaining < loaderBudget {
+			loaderBudget = remaining
+		}
+	}
+	ctx, cancel := context.WithTimeout(parent, loaderBudget)
+	return ctx, cancel, nil
+}

--- a/cache/redis/redis_test.go
+++ b/cache/redis/redis_test.go
@@ -114,3 +114,27 @@ func TestWaitForFillReturnsOnContextCancel(t *testing.T) {
 		t.Fatalf("waitForFill should return quickly on cancellation, took %v", time.Since(start))
 	}
 }
+
+func TestGetOrSetRejectsInvalidTTLBeforeLoader(t *testing.T) {
+	c := &Cache{
+		cfg: cache.Config{DefaultTTL: 0},
+	}
+
+	called := false
+	err := c.GetOrSet(
+		context.Background(),
+		cache.Key{},
+		new(any),
+		0,
+		func(context.Context) (any, error) {
+			called = true
+			return map[string]any{"ok": true}, nil
+		},
+	)
+	if apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input for effective TTL, got: %v", err)
+	}
+	if called {
+		t.Fatal("loader should not be called when effective TTL is invalid")
+	}
+}

--- a/cache/redis/redis_test.go
+++ b/cache/redis/redis_test.go
@@ -1,0 +1,116 @@
+package redis
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/routerarchitects/ra-common-mods/apperror"
+	"github.com/routerarchitects/ra-common-mods/cache"
+)
+
+func TestValidateConfig(t *testing.T) {
+	if err := validateConfig(cache.Config{}); apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input, got: %v", err)
+	}
+	if err := validateConfig(cache.Config{ServiceName: "svc", Addrs: []string{"localhost:6379"}}); err != nil {
+		t.Fatalf("expected valid config, got: %v", err)
+	}
+	if err := validateConfig(cache.Config{ServiceName: "svc", Addrs: []string{"localhost:6379"}, TTLJitterPct: 0.6}); apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input for jitter percent, got: %v", err)
+	}
+	if err := validateConfig(cache.Config{
+		ServiceName:              "svc",
+		Addrs:                    []string{"localhost:6379"},
+		EnableStampedeProtection: true,
+		LockTTL:                  time.Millisecond,
+	}); apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input for lock ttl too small, got: %v", err)
+	}
+}
+
+func TestClusterDBValidation(t *testing.T) {
+	_, err := newClient(cache.Config{Mode: "cluster", Addrs: []string{"127.0.0.1:6379"}, DB: 1})
+	if apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input for cluster db!=0, got: %v", err)
+	}
+}
+
+func TestApplyDefaultsForLockConfig(t *testing.T) {
+	cfg := applyDefaults(cache.Config{})
+	if cfg.LockTTL != 3*time.Second {
+		t.Fatalf("unexpected LockTTL default: %v", cfg.LockTTL)
+	}
+	if cfg.LockWaitTimeout != 2*time.Second {
+		t.Fatalf("unexpected LockWaitTimeout default: %v", cfg.LockWaitTimeout)
+	}
+	if cfg.LockRetryInterval != 100*time.Millisecond {
+		t.Fatalf("unexpected LockRetryInterval default: %v", cfg.LockRetryInterval)
+	}
+}
+
+func TestLoadAndFillRejectsNilLoader(t *testing.T) {
+	builder, err := cache.NewKeyBuilder("svc", "")
+	if err != nil {
+		t.Fatalf("builder error: %v", err)
+	}
+	c := &Cache{
+		cfg:     cache.Config{DefaultTTL: time.Minute},
+		codec:   cache.JSONCodec{},
+		builder: builder,
+	}
+
+	var dest map[string]any
+	err = c.loadAndFill(context.Background(), cache.Key{Domain: "a", Entity: "b", ID: "1"}, &dest, time.Minute, nil)
+	if apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input for nil loader, got: %v", err)
+	}
+}
+
+func TestLoadAndFillReturnsInvalidTTL(t *testing.T) {
+	builder, err := cache.NewKeyBuilder("svc", "")
+	if err != nil {
+		t.Fatalf("builder error: %v", err)
+	}
+	c := &Cache{
+		cfg:     cache.Config{DefaultTTL: 0},
+		codec:   cache.JSONCodec{},
+		builder: builder,
+	}
+
+	var dest map[string]any
+	err = c.loadAndFill(
+		context.Background(),
+		cache.Key{Domain: "a", Entity: "b", ID: "1"},
+		&dest,
+		0,
+		func(context.Context) (any, error) {
+			return map[string]any{"ok": true}, nil
+		},
+	)
+	if apperror.CodeOf(err) != apperror.CodeInvalidInput {
+		t.Fatalf("expected invalid input from Set TTL validation, got: %v", err)
+	}
+}
+
+func TestWaitForFillReturnsOnContextCancel(t *testing.T) {
+	c := &Cache{
+		cfg: cache.Config{
+			LockWaitTimeout:   5 * time.Second,
+			LockRetryInterval: 2 * time.Second,
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var dest any
+	start := time.Now()
+	err := c.waitForFill(ctx, "k", &dest, time.Now())
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if time.Since(start) > 200*time.Millisecond {
+		t.Fatalf("waitForFill should return quickly on cancellation, took %v", time.Since(start))
+	}
+}


### PR DESCRIPTION
## Summary
Introduces a production-ready Redis cache common module in `ra-common-mods/cache` with a clean shared API, structured key generation, TTL handling (including jitter), cache-aside `GetOrSet`, stampede protection, health checks, and standardized error/log behavior via common modules.

## Related Issues
### ✅ Issues closed by this PR
- Closes #20 

## What Changed
- Added cache public contract and core types:
  - `Cache` interface: `Get`, `Set`, `Delete`, `Exists`, `GetOrSet`, `Close`
  - `HealthChecker` interface: `Ping`
  - `Key`, `Config`, `Codec`, and default `JSONCodec`
- Implemented Redis-backed cache:
  - Redis modes: `standalone`, `sentinel`, `cluster`
  - Config validation (including `cluster` with `DB=0`)
  - Redis client setup with timeout defaults
- Implemented opaque key generation and validation:
  - Key format: `<prefix>:<domain>:<entity>:<id>:<qualifiers...>:<version>`
  - `Version` is optional and defaults to `v1`
  - Segment normalization and validation rules (restricted charset, reserved namespace protection)
- Implemented cache operations:
  - `Get`, `Set`, `Delete`, `Exists`, `GetOrSet`, `Close`, `Ping`
- Implemented stampede protection for `GetOrSet`:
  - Internal lock key namespace `__cache_lock__`
  - Lock acquisition via `SETNX` + TTL
  - Safe unlock via Lua compare-and-delete
  - Wait/retry on lock contention with graceful loader fallback
- Added TTL mechanics:
  - TTL resolution (`method ttl` > `DefaultTTL`)
  - Reject non-positive effective TTL
  - Optional TTL jitter with validation (`TTLJitterPct` in `[0.0, 0.5]`)
- Added baseline metrics (Phase 1) using `expvar`:
  - `cache_hit_total`, `cache_miss_total`, `cache_error_total`
  - latency totals for `get`, `set`, `loader`
- Integrated common modules:
  - `apperror` for standardized errors
  - `logger` for structured logs with redacted key exposure (`key_hash`)
- Added/updated documentation and tests:
  - `CACHE_MODULE_SPEC.md`, `README.md`
  - Unit tests for key building/validation and config rules

## Why
Services were duplicating Redis cache logic and handling key generation, TTL, and error/log conventions inconsistently. This module establishes a single reusable cache contract and implementation to improve consistency, reliability, and maintainability across services.

## How to Test
1. Run module tests:
   - `cd cache && go test ./...`
2. Validate key behavior:
   - Confirm version defaults to `v1` when omitted
   - Confirm invalid segments (e.g., `:`, `__`, unsupported chars) are rejected
3. Validate config behavior:
   - Confirm cluster mode rejects `DB != 0`
   - Confirm TTL jitter percent outside `[0.0, 0.5]` is rejected

## Screenshots / Logs (if applicable)
N/A

## Impact
- **Developer impact:** Services can now use one shared cache module instead of custom implementations.
- **Behavior impact:** Standardized cache-aside behavior, key format, and stampede protection.
- **Compatibility:** Backward-compatible at platform level (new module addition), but service integrations should align with new key/TTL rules.
- **Rollout:** Service-by-service adoption; no mandatory migration for unrelated modules.

## Dependencies
- Go module dependencies:
  - `github.com/redis/go-redis/v9`
  - `github.com/google/uuid`
- Internal module dependencies:
  - `github.com/routerarchitects/ra-common-mods/apperror`
  - `github.com/routerarchitects/ra-common-mods/logger`
- No DB migrations required.

## Checklist
- [x] Documentation updated (if applicable)
- [x] Backward compatibility considered

## Notes for Reviewers
- Please focus on:
  - `GetOrSet` lock/fallback behavior under failures
  - Key normalization/validation and namespace rules
  - TTL resolution + jitter semantics
  - Config validation edge cases
  - Baseline metrics coverage and naming